### PR TITLE
Make reddwall more portable

### DIFF
--- a/reddwall
+++ b/reddwall
@@ -1,4 +1,4 @@
-#!/bin/env python3
+#!/usr/bin/env python3
 import json
 from urllib.parse import urlparse
 import urllib.request


### PR DESCRIPTION
`env` is expected at `/usr/bin/` on Unixes.
On ArchLinux (which the original author uses) `/bin/env` is available only because `/bin` is symlinked to `/usr/bin`
